### PR TITLE
Added setting to show remaining time on tab

### DIFF
--- a/source/src/components/SettingsPopUp.js
+++ b/source/src/components/SettingsPopUp.js
@@ -70,6 +70,16 @@ class SettingsPopUp extends HTMLElement {
         }
     }
 
+    toggleTabLabel() {
+        const tabLabel = document.getElementById('tab-label');
+        if (localStorage.getItem('tab-label') === 'on') {
+            localStorage.setItem('tab-label', 'off');
+            tabLabel.innerHTML = 'Pomodoro Timer';
+        } else {
+            localStorage.setItem('tab-label', 'on');
+        }
+    }
+
     setVolume() {
         const volume = this.shadowRoot.getElementById('range').value;
         localStorage.setItem('volume', `${volume}`);
@@ -108,6 +118,9 @@ class SettingsPopUp extends HTMLElement {
             _bindedChangeTheme: {
                 value: this.toggleMode.bind(this),
             },
+            _bindedToggleTabLabel: {
+                value: this.toggleTabLabel.bind(this),
+            },
             _bindedUpdateVolumeText: {
                 value: this.updateVolumeText.bind(this),
             },
@@ -143,6 +156,13 @@ class SettingsPopUp extends HTMLElement {
         }
         const themeStylisticSlider = this.shadowRoot.getElementById('mode-switch-slider');
         themeStylisticSlider.addEventListener('click', this._bindedChangeTheme);
+
+        const tabLabelCheckbox = this.shadowRoot.querySelector('#tab-label-switch > label.switch > input[type=checkbox]');
+        if (localStorage.getItem('tab-label') === 'on') {
+            tabLabelCheckbox.toggleAttribute('checked');
+        }
+        const tabLabelStylisticSlider = this.shadowRoot.getElementById('tab-label-switch-slider');
+        tabLabelStylisticSlider.addEventListener('click', this._bindedToggleTabLabel);
 
         const rangeInput = this.shadowRoot.getElementById('range');
         rangeInput.setAttribute('value', parseInt(localStorage.getItem('volume'), 10));

--- a/source/src/components/html_fragments/SettingsPopUp.html
+++ b/source/src/components/html_fragments/SettingsPopUp.html
@@ -81,6 +81,21 @@
         border-bottom: solid 1px #d2d2d2;
         padding-bottom: 1.5625vw;
     }
+    #enable-tab-label {
+        color: rgb(85, 85, 85);
+        font-weight: 500;
+        margin: 0;
+        display: flex;
+        align-items: center;
+    }
+    #tab-label-switch {
+        justify-content: space-between;
+        display: flex;
+        width: 85%;
+        margin: 1.5625vw auto 0.78125vw auto;
+        border-bottom: solid 1px #d2d2d2;
+        padding-bottom: 1.5625vw;
+    }
     .switch {
         position: relative;
         display: inline-flex;
@@ -305,6 +320,13 @@
         <label class="switch">
             <input type="checkbox">
             <span id="mode-switch-slider" class="slider"></span>
+        </label>
+    </div>
+    <div id="tab-label-switch">
+        <h4 id="enable-tab-label" part="enable-tab-label">Enable Tab Label?</h4>
+        <label class="switch">
+            <input type="checkbox">
+            <span id="tab-label-switch-slider" class="slider"></span>
         </label>
     </div>
     <div id="volume-div">

--- a/source/src/index.html
+++ b/source/src/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-    <title>Pomodoro Timer</title>
+    <title id="tab-label">Pomodoro Timer</title>
     <link rel="stylesheet" href="styles/index.css">
     <link rel="shortcut icon" type="image/x-icon" href="/icons/favicon.ico">
     <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@300;400;500&display=swap" rel="stylesheet">
@@ -242,6 +242,21 @@
             border-bottom: solid 1px #d2d2d2;
             padding-bottom: 1.5625vw;
         }
+        #enable-tab-label {
+            color: rgb(85, 85, 85);
+            font-weight: 500;
+            margin: 0;
+            display: flex;
+            align-items: center;
+        }
+        #tab-label-switch {
+            justify-content: space-between;
+            display: flex;
+            width: 85%;
+            margin: 1.5625vw auto 0.78125vw auto;
+            border-bottom: solid 1px #d2d2d2;
+            padding-bottom: 1.5625vw;
+        }
         .switch {
             position: relative;
             display: inline-flex;
@@ -466,6 +481,13 @@
             <label class="switch">
                 <input type="checkbox">
                 <span id="mode-switch-slider" class="slider"></span>
+            </label>
+        </div>
+        <div id="tab-label-switch">
+            <h4 id="enable-tab-label" part="enable-tab-label">Enable Tab Label?</h4>
+            <label class="switch">
+                <input type="checkbox">
+                <span id="tab-label-switch-slider" class="slider"></span>
             </label>
         </div>
         <div id="volume-div">

--- a/source/src/scripts/Timer.js
+++ b/source/src/scripts/Timer.js
@@ -1,10 +1,12 @@
 const startButton = document.getElementById('start-btn');
 const timerDisplayDuration = document.getElementById('timer_display_duration');
+const tabLabel = document.getElementById('tab-label');
 const btnSound = new Audio('./icons/btnClick.mp3');
 const alarmSound = new Audio('./icons/alarm.mp3');
 const SECOND = 1000;
 let timer;
 let timerStatus = 'pomo';
+let tabLabelStatus = 'Time to Focus!';
 let breakCounter = 0;
 
 // assign default session lengths to local storage
@@ -23,7 +25,7 @@ timerDisplayDuration.innerHTML = `${pomoTime}:00`;
  * This function is used by switchMode() to switch the highlighted button
  * on the UI from pomo to break when switching to break mode.
  */
- function togglePomoButtonOff(pomoButton, breakButton) {
+function togglePomoButtonOff(pomoButton, breakButton) {
     if (pomoButton.getAttribute('class') !== 'toggle') {
         pomoButton.classList.toggle('toggle');
         breakButton.classList.toggle('toggle');
@@ -41,6 +43,15 @@ function togglePomoButtonOn(pomoButton, breakButton) {
     }
 }
 
+/** This function is called to update the tab label with the remaining
+ * time, if the Tab Label setting is enabled.
+*/
+function updateTabLabel(tabLabelTime) {
+    if (localStorage.getItem('tab-label') === 'on') {
+        tabLabel.innerHTML = `${tabLabelTime} - ${tabLabelStatus}`;
+    }
+}
+
 /**
  * The sitchMode function would sitch the time mode if the pomo time is over.
  * the function would switch short break time mode. After three times of short
@@ -49,20 +60,26 @@ function togglePomoButtonOn(pomoButton, breakButton) {
 function switchMode() {
     const pomoButton = document.getElementById('pomo-btn');
     const breakButton = document.getElementById('break-btn');
-    
+
     if (timerStatus === 'pomo' && breakCounter >= 3) {
         timerDisplayDuration.innerHTML = `${longBreakTime}:00`;
         togglePomoButtonOff(pomoButton, breakButton);
+        tabLabelStatus = 'Rest a while!';
+        updateTabLabel(`${longBreakTime}:00`);
         timerStatus = 'break';
         breakCounter = 0;
     } else if (timerStatus === 'pomo') {
         timerDisplayDuration.innerHTML = `${breakTime}:00`;
         togglePomoButtonOff(pomoButton, breakButton);
+        tabLabelStatus = 'Take a break!';
+        updateTabLabel(`${breakTime}:00`);
         timerStatus = 'break';
         breakCounter += 1;
     } else {
         timerDisplayDuration.innerHTML = `${pomoTime}:00`;
         togglePomoButtonOn(pomoButton, breakButton);
+        tabLabelStatus = 'Time to Focus!';
+        updateTabLabel(`${pomoTime}:00`);
         timerStatus = 'pomo';
     }
 }
@@ -103,6 +120,7 @@ async function timerFunction() {
     }
 
     timerDisplayDuration.innerHTML = `${minutes}:${seconds}`;
+    updateTabLabel(`${minutes}:${seconds}`);
 }
 
 /** The function would be call when the click start button and the stop button
@@ -110,6 +128,7 @@ async function timerFunction() {
  */
 async function start() {
     startButton.innerHTML = 'Stop';
+    updateTabLabel(`${pomoTime}:00`);
     timer = setInterval(timerFunction, SECOND);
 }
 

--- a/source/src/scripts/script.js
+++ b/source/src/scripts/script.js
@@ -4,6 +4,7 @@ window.addEventListener('DOMContentLoaded', () => {
     let tasks; // holds list nodes in local storage
     let id; // id counter for task items
     let theme; // UI theme
+    let tabLabel;
     let volume; // default volume -> initialized to 50
     let state; // state -> initialized to 'default'
     let clickState; // record for if click sound is enabled
@@ -18,16 +19,19 @@ window.addEventListener('DOMContentLoaded', () => {
         localStorage.setItem('alarmState', alarmState);
     }
 
-    if (localStorage.getItem('tasks') === null || localStorage.getItem('id') === null || localStorage.getItem('theme') === null || localStorage.getItem('volume') === null
-        || localStorage.getItem('state') === null || localStorage.getItem('clickState') === null || localStorage.getItem('alarmState') === null) {
+    if (localStorage.getItem('tasks') === null || localStorage.getItem('id') === null || localStorage.getItem('theme') === null
+        || localStorage.getItem('tab-label') === null || localStorage.getItem('volume') === null || localStorage.getItem('state') === null
+        || localStorage.getItem('clickState') === null || localStorage.getItem('alarmState') === null) {
         tasks = [];
         id = 0;
         theme = 'light';
+        tabLabel = 'on';
         volume = 50;
         state = 'default';
         localStorage.setItem('tasks', JSON.stringify(tasks));
         localStorage.setItem('id', `${id}`);
         localStorage.setItem('theme', theme);
+        localStorage.setItem('tab-label', tabLabel);
         localStorage.setItem('volume', `${volume}`);
         localStorage.setItem('state', state);
     } else {

--- a/source/src/styles/index.css
+++ b/source/src/styles/index.css
@@ -431,6 +431,10 @@ body.dark-theme settings-popup::part(enable-dark-mode) {
     color: #f5f6f7;
 }
 
+body.dark-theme settings-popup::part(enable-tab-label) {
+    color: #f5f6f7;
+}
+
 body.dark-theme settings-popup::part(btn-footer) {
     background-color: #2d3848;
 }

--- a/source/tests/SettingsPopUp.test.js
+++ b/source/tests/SettingsPopUp.test.js
@@ -181,11 +181,11 @@ test('All attributes set correctly', () => {
     expect(shadow.querySelector('span').getAttribute('class')).toBe('slider');
 
     // volume session set correctly, default volume 50
-    expect(shadow.querySelectorAll('input')[4].getAttribute('type')).toBe('range');
-    expect(shadow.querySelectorAll('input')[4].getAttribute('id')).toBe('range');
-    expect(shadow.querySelectorAll('input')[4].getAttribute('value')).toBe('50');
-    expect(shadow.querySelectorAll('input')[4].getAttribute('min')).toBe('0');
-    expect(shadow.querySelectorAll('input')[4].getAttribute('max')).toBe('100');
+    expect(shadow.querySelectorAll('input')[5].getAttribute('type')).toBe('range');
+    expect(shadow.querySelectorAll('input')[5].getAttribute('id')).toBe('range');
+    expect(shadow.querySelectorAll('input')[5].getAttribute('value')).toBe('50');
+    expect(shadow.querySelectorAll('input')[5].getAttribute('min')).toBe('0');
+    expect(shadow.querySelectorAll('input')[5].getAttribute('max')).toBe('100');
 
     // confirm button attributes set correctly
     expect(shadow.querySelectorAll('button')[0].getAttribute('class')).toBe('settings-popup-btns');

--- a/source/tests/script.test.js
+++ b/source/tests/script.test.js
@@ -46,6 +46,7 @@ function initializeLocalStorage() {
     localStorage.setItem('tasks', '[]');
     localStorage.setItem('id', '0');
     localStorage.setItem('theme', 'light');
+    localStorage.setItem('tab-label', 'on');
     localStorage.setItem('volume', '50');
     localStorage.setItem('state', 'default');
 }


### PR DESCRIPTION
==Changelog==
- added a function to change site title when the time is updated
- added toggle for tab label to settings pop up
- added setting info to localstorage

==Testing==
- manually checked that remaining time is displayed only when toggle is on
- manually checked that setting choices persist after refreshing the page
- automated tests not done yet

==Version Compatibility==

==Detail Description==
- added updateTabLabel() function in Timer.js which checks localstorage and updates
  the title element if the setting is turned on
- copied the same format from the dark mode toggle to add a tab label
  toggle to the settings template
- added toggleTabLabel() method in SettingsPopUp.js (and binded to tab
  label toggle)
- updated tests that were broken from adding the toggle
- still waiting for kai's fix to the settings popup to be merged to dev