### PR TITLE
Small bugfixes for tab label

### DIFF
--- a/source/src/components/SettingsPopUp.js
+++ b/source/src/components/SettingsPopUp.js
@@ -158,7 +158,7 @@ class SettingsPopUp extends HTMLElement {
         themeStylisticSlider.addEventListener('click', this._bindedChangeTheme);
 
         const tabLabelCheckbox = this.shadowRoot.querySelector('#tab-label-switch > label.switch > input[type=checkbox]');
-        if (localStorage.getItem('tab-label') === 'on') {
+        if (localStorage.getItem('tab-label') === 'on' || localStorage.getItem('tab-label') === null) {
             tabLabelCheckbox.toggleAttribute('checked');
         }
         const tabLabelStylisticSlider = this.shadowRoot.getElementById('tab-label-switch-slider');

--- a/source/src/scripts/Timer.js
+++ b/source/src/scripts/Timer.js
@@ -1,7 +1,6 @@
 const startButton = document.getElementById('start-btn');
 const timerDisplayDuration = document.getElementById('timer_display_duration');
 const timerBackground = document.getElementById('timer_display');
-const tabLabel = document.getElementById('tab-label');
 const btnSound = new Audio('./icons/btnClick.mp3');
 const alarmSound = new Audio('./icons/alarm.mp3');
 const SECOND = 1000;
@@ -45,10 +44,14 @@ function togglePomoButtonOn(pomoButton, breakButton) {
 }
 
 /** This function is called to update the tab label with the remaining
- * time, if the Tab Label setting is enabled.
+ * time, if the Tab Label setting is enabled. It can also be used to
+ * set the tab label back to normal text by passing null as the argument.
  */
 function updateTabLabel(tabLabelTime) {
-    if (localStorage.getItem('tab-label') === 'on') {
+    const tabLabel = document.getElementById('tab-label');
+    if (tabLabelTime === null) {
+        tabLabel.innerHTML = 'Pomodoro Timer';
+    } else if (localStorage.getItem('tab-label') === 'on') {
         tabLabel.innerHTML = `${tabLabelTime} - ${tabLabelStatus}`;
     }
 }
@@ -161,7 +164,10 @@ async function stop() {
     longBreakTime = localStorage.getItem('long-break-length');
     clearInterval(timer);
     timerStatus = 'break';
-    setTimeout(switchMode, SECOND / 10);
+    setTimeout(() => {
+        switchMode();
+        updateTabLabel(null);
+    }, SECOND / 10);
     breakCounter = 0;
     startButton.innerHTML = 'Start';
     timerBackground.style.background = `linear-gradient(0deg, 

--- a/source/tests/Timer.test.js
+++ b/source/tests/Timer.test.js
@@ -48,6 +48,9 @@ test('start timer function', () => {
 });
 
 test('Stop and reset function', () => {
+    document.head.innerHTML = `
+        <title id="tab-label">Pomodoro Timer</title>
+    `;
     document.body.innerHTML = `
         <button id = "start-btn">Stop</button>
         <button id="pomo-btn"> Pomo</button>


### PR DESCRIPTION
==Changelog==
- fix toggle not showing as on in settings when starting app for the
  first time
- tab label returns to normal text after timer is stopped

==Testing==
- manual check to see that tab label goes back to "Pomodoro Timer" when
  timer is started and then stopped
- manual check on brooks computer that the toggle is initialized correctly with
  this fix

==Version Compatibility==

==Detail Description==
- added a line to the setTimeout callback in the stop() function in
  Timer.js to set the tab label text to "Pomodoro Timer"
- added a null check in SettingsPopUp.js when checking localStorage for
  the tab-label setting to initialize the toggle