### PR TITLE
Small bugfix for single digit seconds on tab label

### DIFF
--- a/source/src/scripts/Timer.js
+++ b/source/src/scripts/Timer.js
@@ -126,10 +126,10 @@ async function timerFunction() {
     }
 
     timerDisplayDuration.innerHTML = `${minutes}:${seconds}`;
+    updateTabLabel(`${minutes}:${seconds}`);
     // Adapt to each modes
     const timeMin = parseInt(timerDisplayDuration.innerHTML.split(':')[0], 10);
     const timeSec = parseInt(timerDisplayDuration.innerHTML.split(':')[1], 10);
-    updateTabLabel(`${timeMin}:${timeSec}`);
     let pomoMode = true;
     const pomoButton = document.getElementById('pomo-btn');
     pomoMode = (pomoButton.getAttribute('class') !== 'toggle');


### PR DESCRIPTION
==Changelog==
- pass the same string values from the timerDisplayDuration to
  updateTabLabel()

==Testing==
- manual check to see that it displays single digit seconds correctly

==Version Compatibility==

==Detail Description==
- updateTabLabel() was being passed an int argument which caused it to
  display single digit seconds incorrectly as :x instead of :0x. For
  example the tab label would show "24:9" instead of "24:09".
- i fixed it by passing the same string arguments that were used for
  setting the timerDisplayDuration