### PR TITLE
Fix cypress tests and increase size of timer display

### DIFF
--- a/source/cypress/integration/pomo-tests.js
+++ b/source/cypress/integration/pomo-tests.js
@@ -32,7 +32,7 @@ describe(('task list and timer'), () => {
             expect(localStorage.getItem('tasks')).contains('test item 1');
         });
         // timer runs without affect
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 
     it('add task when timer has started (keyboard)', () => {
@@ -64,20 +64,20 @@ describe(('task list and timer'), () => {
             expect(localStorage.getItem('tasks')).contains('test item 1');
         });
         // timer runs without affect
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 
     it(('start the timer while adding the task'), () => {
         cy.get('#task-popup-btn').trigger('click');
         cy.get('#start-btn').trigger('click');
         // timer runs without affect
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('task-popup').shadow()
             .find('#task-input')
             .type('test item 1', { force: true });
         // interact with the timer
         cy.get('#start-btn').trigger('click');
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.get('#start-btn').trigger('click');
         cy.get('#focus-button').trigger('click');
         cy.get('task-popup').shadow()
@@ -90,7 +90,7 @@ describe(('task list and timer'), () => {
             expect(localStorage.getItem('id')).contains('1');
             expect(localStorage.getItem('tasks')).contains('test item 1');
         });
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 
     it('cancel add task when timer has started', () => {
@@ -102,7 +102,7 @@ describe(('task list and timer'), () => {
             .find('#close-icon').trigger('click');
         // timer runs without affect
         cy.get('task-item').should('have.length', 0);
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 
     it(('start the timer while adding the task then cancel'), () => {
@@ -110,11 +110,11 @@ describe(('task list and timer'), () => {
         cy.get('#start-btn').trigger('click');
         cy.get('#focus-button').trigger('click');
         // timer runs without affect
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('task-popup').shadow()
             .find('#close-icon').trigger('click');
         cy.get('task-item').should('have.length', 0);
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 });
 
@@ -143,7 +143,7 @@ describe(('interact with exist task list while timer is runing'), () => {
         cy.get('#0').should('have.css', 'display', 'flex');
         cy.get('#0').trigger('click');
         cy.get('#0').should('have.css', 'display', 'none');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 
     it(('delete the tasks while timer is runing'), () => {
@@ -152,7 +152,7 @@ describe(('interact with exist task list while timer is runing'), () => {
         cy.get('#0').shadow()
             .find('img[src="icons/delete.svg"]').click({ force: true });
         cy.get('#0').should('have.length', 0);
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 
     it(('switch a focus on a task while timer is running'), () => {
@@ -161,14 +161,14 @@ describe(('interact with exist task list while timer is runing'), () => {
         // focus task is set correctly
         cy.get('#0').parent().should('have.id', 'focus-task');
         cy.get('#1').parent().should('have.id', 'task-list-elements');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 
     it(('unfocus a task while timer is runing'), () => {
         cy.get('#start-btn').trigger('click');
         cy.get('#1').shadow().find('img[class="focus-icon"]').click({ force: true });
         cy.get('#1').parent().should('have.id', 'task-list-elements');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
     });
 });
 
@@ -195,10 +195,10 @@ describe('reset popup and timer', () => {
         cy.get('#1').shadow().find('img[class="focus-icon"]').click({ force: true });
         cy.get('#start-btn').click();
         cy.get('#reset-button').click();
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('reset-popup').shadow()
             .find('#confirm-reset-btn').click();
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.get('#start-btn').should('have.text', 'Start');
         cy.get('task-item').should('have.length', 0);
         cy.url().should(() => {
@@ -210,10 +210,10 @@ describe('reset popup and timer', () => {
     it(('start the timer when reset'), () => {
         cy.get('#reset-button').click();
         cy.get('#start-btn').click();
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('reset-popup').shadow()
             .find('#confirm-reset-btn').click();
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.get('#start-btn').should('have.text', 'Start');
         cy.get('task-item').should('have.length', 0);
         cy.url().should(() => {
@@ -225,10 +225,10 @@ describe('reset popup and timer', () => {
     it(('reset then cancel when timer has started'), () => {
         cy.get('#start-btn').click();
         cy.get('#reset-button').click();
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('reset-popup').shadow()
             .find('#close-icon').click();
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#start-btn').should('have.text', 'Stop');
         cy.get('task-item').should('have.length', 2);
     });
@@ -236,10 +236,10 @@ describe('reset popup and timer', () => {
     it(('start the timer when reset then cancel'), () => {
         cy.get('#reset-button').click();
         cy.get('#start-btn').click();
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('reset-popup').shadow()
             .find('#close-icon').click();
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#start-btn').should('have.text', 'Stop');
         cy.get('task-item').should('have.length', 2);
     });
@@ -253,7 +253,7 @@ describe('setting popup and timer', () => {
     it(('set time while timer is runing, stop and reset the timer'), () => {
         // start the timer
         cy.get('#start-btn').trigger('click');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         // set the times
         cy.get('#setting-button').trigger('click');
         cy.get('settings-popup').shadow()
@@ -269,13 +269,13 @@ describe('setting popup and timer', () => {
             .find('#confirm-settings-btn')
             .trigger('click');
         // check pomo time
-        cy.get('#timer_display_duration').should('have.text', '3:00');
+        cy.get('#timer-display-duration').should('have.text', '3:00');
         cy.get('#start-btn').should('have.text', 'Start');
         cy.clock();
         cy.get('#start-btn').trigger('click');
         // check short break time
         cy.tick(181000);
-        cy.get('#timer_display_duration').should('have.text', '0:59');
+        cy.get('#timer-display-duration').should('have.text', '0:59');
         // check long break time
         cy.tick(59000);
         cy.tick(180000);
@@ -283,7 +283,7 @@ describe('setting popup and timer', () => {
         cy.tick(180000);
         cy.tick(60000);
         cy.tick(181000);
-        cy.get('#timer_display_duration').should('have.text', '1:59');
+        cy.get('#timer-display-duration').should('have.text', '1:59');
         // test when class are toggled
         cy.get('#start-btn').trigger('click');
         cy.get('#start-btn').trigger('click');
@@ -298,7 +298,7 @@ describe('setting popup and timer', () => {
         cy.tick(180000);
         cy.get('#pomo-btn').invoke('attr', 'class', 'toggle');
         cy.tick(1000);
-        cy.get('#timer_display_duration').should('have.text', '1:59');
+        cy.get('#timer-display-duration').should('have.text', '1:59');
     });
 
     it(('set time incorrectly resets values to default'), () => {
@@ -316,13 +316,13 @@ describe('setting popup and timer', () => {
             .find('#confirm-settings-btn')
             .trigger('click');
 
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.get('#start-btn').should('have.text', 'Start');
     });
 
     it(('set time then cancel while timer is runing'), () => {
         cy.get('#start-btn').trigger('click');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#setting-button').trigger('click');
         cy.get('settings-popup').shadow()
             .find('#pomo-length-input')
@@ -330,23 +330,23 @@ describe('setting popup and timer', () => {
         cy.get('settings-popup').shadow()
             .find('#close-icon')
             .trigger('click');
-        cy.get('#timer_display_duration').should('have.text', '24:57');
+        cy.get('#timer-display-duration').should('have.text', '24:57');
         cy.get('#start-btn').should('have.text', 'Stop');
     });
 
     it(('switch to dark mode while timer is runing'), () => {
         cy.get('#start-btn').trigger('click');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#setting-button').trigger('click');
         cy.get('settings-popup').shadow()
             .find('span[id="mode-switch-slider"]')
             .click();
-        cy.get('#timer_display_duration').should('have.text', '24:57');
+        cy.get('#timer-display-duration').should('have.text', '24:57');
         cy.get('settings-popup').shadow()
             .find('#confirm-settings-btn')
             .click();
         // should reset now
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.url().should(() => {
             expect(localStorage.getItem('theme')).contains('dark');
         });
@@ -354,7 +354,7 @@ describe('setting popup and timer', () => {
 
     it(('set volume while timer is runing'), () => {
         cy.get('#start-btn').trigger('click');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#setting-button').trigger('click');
         cy.get('settings-popup').shadow()
             .find('#range')
@@ -368,7 +368,7 @@ describe('setting popup and timer', () => {
         });
         cy.get('settings-popup').shadow()
             .find('#volume-number').should('have.text', '30');
-        cy.get('#timer_display_duration').should('have.text', '24:57');
+        cy.get('#timer-display-duration').should('have.text', '24:57');
     });
 });
 
@@ -379,19 +379,19 @@ describe(('helping popup and timer'), () => {
 
     it(('view help popup while timer is runing'), () => {
         cy.get('#start-btn').trigger('click');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#help-button').click();
         cy.get('help-popup').shadow()
             .find('#help-popup')
             .should('have.css', 'display', 'block');
-        cy.get('#timer_display_duration').should('have.text', '24:58');
+        cy.get('#timer-display-duration').should('have.text', '24:58');
         cy.get('help-popup').shadow()
             .find('#close-icon')
             .click();
         cy.get('help-popup').shadow()
             .find('#help-popup')
             .should('have.css', 'display', 'none');
-        cy.get('#timer_display_duration').should('have.text', '24:56');
+        cy.get('#timer-display-duration').should('have.text', '24:56');
     });
 });
 
@@ -409,12 +409,12 @@ describe(('in dark mode'), () => {
     });
     it(('switch to light mode while timer is runing'), () => {
         cy.get('#start-btn').trigger('click');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#setting-button').trigger('click');
         cy.get('settings-popup').shadow()
             .find('span[id="mode-switch-slider"]')
             .trigger('click');
-        cy.get('#timer_display_duration').should('have.text', '24:57');
+        cy.get('#timer-display-duration').should('have.text', '24:57');
         cy.url().should(() => {
             expect(localStorage.getItem('theme')).contains('light');
         });
@@ -428,21 +428,21 @@ describe(('toggle focus mode while timer is runing'), () => {
     it(('toggle to focus mode'), () => {
         cy.get('#start-btn').trigger('click');
         cy.get('#focus-button').trigger('click');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#focus-button').click();
         // state changed successfully
         cy.url().should(() => {
             expect(localStorage.getItem('state')).contains('focus');
         });
         // timer runs as intended
-        cy.get('#timer_display_duration').should('have.text', '24:58');
+        cy.get('#timer-display-duration').should('have.text', '24:58');
         cy.get('#start-btn').should('have.text', 'Stop');
         // toggle back to normal mode
         cy.get('#focus-button').click();
         cy.url().should(() => {
             expect(localStorage.getItem('state')).contains('default');
         });
-        cy.get('#timer_display_duration').should('have.text', '24:56');
+        cy.get('#timer-display-duration').should('have.text', '24:56');
         cy.get('#start-btn').should('have.text', 'Stop');
     });
 });
@@ -529,7 +529,7 @@ describe(('keyboard shortcut and focus mode'), () => {
         cy.get('body').type('q');
         cy.get('body').type('{enter}');
         cy.get('body').type('{esc}');
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.get('reset-popup').shadow()
             .find('#reset-confirm-popup').should('have.css', 'display', 'none');
         cy.get('help-popup').shadow()
@@ -546,10 +546,10 @@ describe(('keyboard shortcut and focus mode'), () => {
     });
     it(('start and stop the timer'), () => {
         cy.get('body').type(' ');
-        cy.get('#timer_display_duration').should('not.have.text', '25:00');
+        cy.get('#timer-display-duration').should('not.have.text', '25:00');
         cy.get('#start-btn').should('have.text', 'Stop');
         cy.get('body').type(' ');
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.get('#start-btn').should('have.text', 'Start');
     });
 
@@ -578,7 +578,7 @@ describe(('keyboard shortcut and focus mode'), () => {
         cy.get('body').type('{esc}');
         cy.get('settings-popup').shadow()
             .find('#settings-confirm-popup').should('have.css', 'display', 'none');
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         // set and confirm
         cy.get('body').type(';');
         cy.get('settings-popup').shadow()
@@ -589,7 +589,7 @@ describe(('keyboard shortcut and focus mode'), () => {
         cy.get('body').type('{enter}');
         cy.get('settings-popup').shadow()
             .find('#settings-confirm-popup').should('have.css', 'display', 'none');
-        cy.get('#timer_display_duration').should('have.text', '3:00');
+        cy.get('#timer-display-duration').should('have.text', '3:00');
     });
 
     it(('help popup'), () => {
@@ -625,7 +625,7 @@ describe(('keyboard shortcut and focus mode'), () => {
         cy.get('task-popup').shadow()
             .find('#add-task-popup').invoke('attr', 'style', 'display: inline');
         cy.get('body').type('s');
-        cy.get('#timer_display_duration').should('have.text', '25:00');
+        cy.get('#timer-display-duration').should('have.text', '25:00');
         cy.get('reset-popup').shadow()
             .find('#reset-confirm-popup').should('have.css', 'display', 'none');
         cy.get('help-popup').shadow()

--- a/source/src/components/SettingsPopUp.js
+++ b/source/src/components/SettingsPopUp.js
@@ -13,7 +13,7 @@ class SettingsPopUp extends HTMLElement {
     }
 
     closePopUp() {
-        const timerBackground = document.getElementById('timer_display');
+        const timerBackground = document.getElementById('timer-display');
         const themeCheckbox = this.shadowRoot.querySelector('#dark-mode > label.switch > input[type=checkbox]');
 
         if ((localStorage.getItem('theme') === 'light') && document.body.classList.contains('dark-theme')) {
@@ -119,7 +119,7 @@ class SettingsPopUp extends HTMLElement {
     }
 
     toggleMode() {
-        const timerBackground = document.getElementById('timer_display');
+        const timerBackground = document.getElementById('timer-display');
         if (localStorage.getItem('theme') === 'light') {
             timerBackground.style.background = '#4a5568';
             // localStorage.setItem('theme', 'dark');

--- a/source/src/components/TaskItem.js
+++ b/source/src/components/TaskItem.js
@@ -140,6 +140,9 @@ class TaskItem extends HTMLElement {
         shadow.appendChild(templateContent.cloneNode(true));
 
         Object.defineProperties(this, {
+            _bindedToggle: {
+                value: this.toggle.bind(this),
+            },
             _bindedFocus: {
                 value: this.focus.bind(this),
             },
@@ -159,7 +162,7 @@ class TaskItem extends HTMLElement {
         // this.setAttribute('text', task.text);
 
         // add event listener such that clicking on element crosses out task
-        this.addEventListener('click', this.toggle);
+        this.shadowRoot.addEventListener('click', this._bindedToggle);
 
         // We add these event listeners here since they require these icons in
         // the DOM to actually function. Otherwise, how else would they be used

--- a/source/src/index.html
+++ b/source/src/index.html
@@ -856,8 +856,8 @@
                     <button id="pomo-btn"> Pomo</button>
                     <button id="break-btn"> Break</button>
                 </div>
-                <div id="timer_display" class="timer-value">
-                    <div id="timer_display_duration">25:00</div>
+                <div id="timer-display" class="timer-value">
+                    <div id="timer-display-duration">25:00</div>
                 </div>
                 <div id="timer-control-btns" class="timer-control-buttons">
                     <button id="start-btn">Start</button>

--- a/source/src/scripts/Timer.js
+++ b/source/src/scripts/Timer.js
@@ -1,7 +1,7 @@
 // import toggleState from '/scripts/FocusMode.js';
 const startButton = document.getElementById('start-btn');
-const timerDisplayDuration = document.getElementById('timer_display_duration');
-const timerBackground = document.getElementById('timer_display');
+const timerDisplayDuration = document.getElementById('timer-display-duration');
+const timerBackground = document.getElementById('timer-display');
 const btnSound = new Audio('./icons/btnClick.mp3');
 const alarmSound = new Audio('./icons/alarm.mp3');
 const SECOND = 1000;

--- a/source/src/styles/index.css
+++ b/source/src/styles/index.css
@@ -70,6 +70,7 @@
 html {
     height: 100%;
 }
+
 ul{
     margin-block-start: 0px;
     margin-block-end: 0px;
@@ -92,6 +93,9 @@ body {
 
 #container {
     width: 100%;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
 }
 
 header {
@@ -213,19 +217,20 @@ main {
     display: flex;
     flex-wrap: wrap;
     flex-direction: row;
-    justify-content: space-between;
     align-items:center;
     margin-left: 10%;
     margin-right: 10%;
+    height: 100%;
 }
 #pomodoro-timer {
     display: inline-flex;
     flex-direction: column;
     align-items: center;
-    justify-content: space-around;
+    justify-content: space-between;
     height: max-content;
     width: max-content;
-    margin: 0px auto auto auto;
+    margin: 0 auto auto auto;
+    height: 90%
 }
 #task-list ul {
     /* list-style-type: none; */
@@ -344,9 +349,17 @@ div.timer-value {
     border-radius: 3.90625vw;
     text-align: center;
     padding: 30px; 
-    width:80%; 
+    width: 80%; 
+
+    display: flex;
+    flex: 2;
+    flex-direction: column;
+    justify-items: center;
 }
 
+#timer-display-duration {
+    margin: auto;
+}
 
 /* CSS for Start/Reset Buttons */
 
@@ -643,6 +656,7 @@ body.dark-theme settings-popup::part(enable-disable-alarmsound) {
 #focus-task task-item {
     width: 80%;
     border-left: solid 5px #eaeaea;
+    display: flex;
 }
 
 
@@ -668,7 +682,7 @@ body.dark-theme settings-popup::part(enable-disable-alarmsound) {
 
 #pomodoro-timer.state {
     width: auto;
-    margin: auto;
+    /* margin: auto; */
 }
 
 

--- a/source/tests/SettingsPopUp.test.js
+++ b/source/tests/SettingsPopUp.test.js
@@ -17,8 +17,8 @@ beforeAll(async () => {
             <img src="../icons/settings.svg" id="gear" class="top-button-img" alt="gear">
             <p class="top-button-text">Setting</p>
         </button>
-        <div id="timer_display" class="timer-value">
-            <div id="timer_display_duration">25:00</div>
+        <div id="timer-display" class="timer-value">
+            <div id="timer-display-duration">25:00</div>
         </div>
         <button id = "start-btn">Start</button>
     `;

--- a/source/tests/Timer.test.js
+++ b/source/tests/Timer.test.js
@@ -28,8 +28,8 @@ afterEach(() => {
 test('start timer function', () => {
     document.body.innerHTML = `
         <button id = "start-btn">Start</button>
-        <div id="timer_display" class="timer-value">
-            <div id="timer_display_duration">25:00</div>
+        <div id="timer-display" class="timer-value">
+            <div id="timer-display-duration">25:00</div>
         </div>
         <button id = "pomo-btn"> Pomo</button>
     `;
@@ -37,7 +37,7 @@ test('start timer function', () => {
     require('../src/scripts/Timer');
 
     const startButton = document.getElementById('start-btn');
-    const display = document.getElementById('timer_display_duration');
+    const display = document.getElementById('timer-display-duration');
 
     startButton.click();
 
@@ -56,15 +56,15 @@ test('Stop and reset function', () => {
         <button id="pomo-btn"> Pomo</button>
         <button id="break-btn"> Break</button>
         <button id = "pomo-btn"> Pomo</button>
-        <div id="timer_display" class="timer-value">
-            <div id="timer_display_duration">13:00</div>
+        <div id="timer-display" class="timer-value">
+            <div id="timer-display-duration">13:00</div>
         </div>
     `;
 
     require('../src/scripts/Timer');
 
     const startButton = document.getElementById('start-btn');
-    const display = document.getElementById('timer_display_duration');
+    const display = document.getElementById('timer-display-duration');
 
     startButton.click();
     jest.advanceTimersByTime(100);
@@ -77,15 +77,15 @@ test('advance in time', () => {
     document.body.innerHTML = `
         <button id = "start-btn">Start</button>
         <button id = "pomo-btn"> Pomo</button>
-        <div id="timer_display" class="timer-value">
-            <div id="timer_display_duration">25:00</div>
+        <div id="timer-display" class="timer-value">
+            <div id="timer-display-duration">25:00</div>
         </div>
     `;
 
     require('../src/scripts/Timer');
 
     const startButton = document.getElementById('start-btn');
-    const display = document.getElementById('timer_display_duration');
+    const display = document.getElementById('timer-display-duration');
 
     startButton.click();
 
@@ -111,8 +111,8 @@ test('advance in time', () => {
 test('stop() called when localStorage stop value is true', () => {
     document.body.innerHTML = `
         <button id = "start-btn">Start</button>
-        <div id="timer_display" class="timer-value">
-            <div id="timer_display_duration">25:00</div>
+        <div id="timer-display" class="timer-value">
+            <div id="timer-display-duration">25:00</div>
         </div>
         <button id="pomo-btn"> Pomo</button>
         <button id="break-btn"> Break</button>
@@ -140,8 +140,8 @@ describe(('switch mode'), () => {
     test('pomo section ends', async () => {
         document.body.innerHTML = `
             <button id = "start-btn">Start</button>
-            <div id="timer_display" class="timer-value">
-                <div id="timer_display_duration">3:00</div>
+            <div id="timer-display" class="timer-value">
+                <div id="timer-display-duration">3:00</div>
             </div>
             <button id = "pomo-btn"> Pomo</button>
             <button style="background-color: #f3606060;" id = "break-btn"> Break</button>
@@ -150,7 +150,7 @@ describe(('switch mode'), () => {
         require('../src/scripts/Timer');
 
         const startButton = document.getElementById('start-btn');
-        const display = document.getElementById('timer_display_duration');
+        const display = document.getElementById('timer-display-duration');
         const pomoButton = document.getElementById('pomo-btn');
         const breakButton = document.getElementById('break-btn');
 
@@ -170,8 +170,8 @@ describe(('switch mode'), () => {
     test('break section ends', async () => {
         document.body.innerHTML = `
             <button id = "start-btn">Start</button>
-            <div id="timer_display" class="timer-value">
-                <div id="timer_display_duration">0:01</div>
+            <div id="timer-display" class="timer-value">
+                <div id="timer-display-duration">0:01</div>
             </div>
             <button id = "pomo-btn"> Pomo</button>
             <button style="background-color: #f3606060;" id = "break-btn"> Break</button>
@@ -180,7 +180,7 @@ describe(('switch mode'), () => {
         require('../src/scripts/Timer');
 
         const startButton = document.getElementById('start-btn');
-        const display = document.getElementById('timer_display_duration');
+        const display = document.getElementById('timer-display-duration');
         const pomoButton = document.getElementById('pomo-btn');
         const breakButton = document.getElementById('break-btn');
 
@@ -202,8 +202,8 @@ describe(('switch mode'), () => {
     test('switch to long break when class is not toggle', () => {
         document.body.innerHTML = `
             <button id = "start-btn">Start</button>
-            <div id="timer_display" class="timer-value">
-                <div id="timer_display_duration">0:01</div>
+            <div id="timer-display" class="timer-value">
+                <div id="timer-display-duration">0:01</div>
             </div>
             <button id = "pomo-btn"> Pomo</button>
             <button style="background-color: #f3606060;" id = "break-btn"> Break</button>
@@ -212,7 +212,7 @@ describe(('switch mode'), () => {
         require('../src/scripts/Timer');
 
         const startButton = document.getElementById('start-btn');
-        const display = document.getElementById('timer_display_duration');
+        const display = document.getElementById('timer-display-duration');
         const pomoButton = document.getElementById('pomo-btn');
         const breakButton = document.getElementById('break-btn');
 
@@ -246,8 +246,8 @@ describe(('switch mode'), () => {
     test('switch to long break when class is toggle', () => {
         document.body.innerHTML = `
             <button id = "start-btn">Start</button>
-            <div id="timer_display" class="timer-value">
-                <div id="timer_display_duration">0:01</div>
+            <div id="timer-display" class="timer-value">
+                <div id="timer-display-duration">0:01</div>
             </div>
             <button id = "pomo-btn"> Pomo</button>
             <button style="background-color: #f3606060;" id = "break-btn"> Break</button>
@@ -256,7 +256,7 @@ describe(('switch mode'), () => {
         require('../src/scripts/Timer');
 
         const startButton = document.getElementById('start-btn');
-        const display = document.getElementById('timer_display_duration');
+        const display = document.getElementById('timer-display-duration');
         const pomoButton = document.getElementById('pomo-btn');
         const breakButton = document.getElementById('break-btn');
 
@@ -325,8 +325,8 @@ describe(('keyboard input'), () => {
                     <h2 id='select-focus'></h2>
                 </div>
                 <button id = "start-btn">Start</button>
-                <div id="timer_display" class="timer-value">
-                    <div id="timer_display_duration">25:00</div>
+                <div id="timer-display" class="timer-value">
+                    <div id="timer-display-duration">25:00</div>
                 </div>
             </div>
             <div id="task-list">
@@ -412,7 +412,7 @@ describe(('keyboard input'), () => {
         document.body.dispatchEvent(eventObj);
 
         const startButton = document.getElementById('start-btn');
-        const display = document.getElementById('timer_display_duration');
+        const display = document.getElementById('timer-display-duration');
 
         jest.advanceTimersByTime(5000);
 
@@ -424,8 +424,8 @@ describe(('keyboard input'), () => {
         document.body.innerHTML = `
             ${templates}
             <button id = "start-btn">Stop</button>
-            <div id="timer_display" class="timer-value">
-                <div id="timer_display_duration">25:00</div>
+            <div id="timer-display" class="timer-value">
+                <div id="timer-display-duration">25:00</div>
             </div>
             <ul id="task-list-elements">
             </ul>
@@ -467,7 +467,7 @@ describe(('keyboard input'), () => {
         document.body.dispatchEvent(eventObj);
 
         const startButton = document.getElementById('start-btn');
-        const display = document.getElementById('timer_display_duration');
+        const display = document.getElementById('timer-display-duration');
 
         jest.advanceTimersByTime(5000);
 


### PR DESCRIPTION
==Changelog==
- Fix task item event listener
- Increase size of timer display to easier distinguish passage of time

==Testing==
- Updated automated testing

==Version Compatibility==
- N/A

==Detail Description==
- Bind task item event listener to shadow DOM
- Increased size of timer display when there is vertical space