### PR TITLE
Label typo fix + Focus button always opaque

### DIFF
--- a/source/src/components/html_fragments/SettingsPopUp.html
+++ b/source/src/components/html_fragments/SettingsPopUp.html
@@ -257,7 +257,7 @@
             <input type="number" id="short-break-input" min="1" max="60" part="length-inputs">
         </div>
         <div class="session-inputs">
-            <label for="long-break" part="session-labels">Short Break</label>
+            <label for="long-break" part="session-labels">Long Break</label>
             <input type="number" id="long-break-input" min="1" max="60" part="length-inputs">
         </div>
     </div>

--- a/source/src/index.html
+++ b/source/src/index.html
@@ -451,7 +451,7 @@
                 <input type="number" id="short-break-input" min="1" max="60" part="length-inputs">
             </div>
             <div class="session-inputs">
-                <label for="long-break" part="session-labels">Short Break</label>
+                <label for="long-break" part="session-labels">Long Break</label>
                 <input type="number" id="long-break-input" min="1" max="60" part="length-inputs">
             </div>
         </div>
@@ -869,7 +869,7 @@
             <nav id="header-buttons">
                 <ul>
                     <li title="Focus">
-                        <button class="top-buttons" id="focus-button">
+                        <button id="focus-button">
                             <img src="icons/half-moon.svg" id="focus" class="top-button-img" alt="Focus">
                         </button>
                     </li>

--- a/source/src/styles/index.css
+++ b/source/src/styles/index.css
@@ -125,6 +125,22 @@ h1#header-name {
     display: inline-block;
 }
 
+#focus-button {
+    cursor: pointer;
+    border-style: none;
+    border-radius: 10%;
+    text-align: center;
+    background-color: #f36060;
+    color: #fff;
+    outline: none;
+    height: var(--top-button-height);
+    width: var(--top-button-width);
+}
+
+#focus-button:hover {
+    transform: scale(1.1);
+}
+
 .top-buttons {
     cursor: pointer;
     border-style: none;
@@ -428,6 +444,11 @@ body.dark-theme {
 }
 
 body.dark-theme h1#header-name {
+    color: #f5f6f7;
+}
+
+body.dark-theme #focus-button {
+    background-color: #4a5568;
     color: #f5f6f7;
 }
 


### PR DESCRIPTION
==Changelog==
- Fixed Setting Popup display bug
- Improved UX when in focus mode
- Fixes issue number #61

==Testing==
- manul testing performed, not much changed

==Version Compatibility==
- N/A

==Detail Description==
- Fixed "Long break" display to be typoed as "short break"
- Made focus button always stay as opaque